### PR TITLE
Update java_transport.md

### DIFF
--- a/versioned_docs/version-1.33.0/client/java/partials/java_transport.md
+++ b/versioned_docs/version-1.33.0/client/java/partials/java_transport.md
@@ -132,8 +132,8 @@ example:
 Anonymous connection:
 
 ```ini
-spark.openlineage.transport.type=http
-spark.openlineage.transport.url=http://localhost:5000
+openlineage.transport.type=http
+openlineage.transport.url=http://localhost:5000
 ```
 
 With authorization:


### PR DESCRIPTION
Changes : remove spark. prefix

Remove because there is a `spark.` prefix in the flink config sub-content.

The option `openlineage.transport.type=http`, `openlineage.transport.url=http://localhost:5000` verified a normal run during a flink application deployment.